### PR TITLE
feat: nextjs-mcp-js quickstart content-type update, new CIMD tenant setting mention

### DIFF
--- a/auth-for-mcp/fastmcp-mcp-js/README.md
+++ b/auth-for-mcp/fastmcp-mcp-js/README.md
@@ -46,9 +46,10 @@ auth0 tenants list
 
 ### Step 2: Configure Tenant Settings
 
-Next, enable tenant-level flags required for Dynamic Client Registration (DCR) and an improved user consent experience.
+Next, enable tenant-level flags required for Client ID Metadata Document (CIMD) and Dynamic Client Registration (DCR) registration for an improved user consent experience.
 
-- `enable_dynamic_client_registration`: Allows MCP tools to register themselves as applications automatically.
+- `client_id_metadata_document_supported`: Allows MCP tools to be accessed by CIMD clients. MCP Clients should prioritize pre-registered clients and CIMD clients prior to using DCR per the current [MCP specification](https://modelcontextprotocol.io/specification/2025-11-25/basic/authorization#client-registration-approaches).
+- `enable_dynamic_client_registration`: Allows MCP tools to register themselves as applications automatically via DCR.
   [Learn more](https://auth0.com/docs/get-started/applications/dynamic-client-registration#enable-dynamic-client-registration)
 - `use_scope_descriptions_for_consent`: Shows user-friendly descriptions for scopes on the consent screen.
   [Learn more](https://auth0.com/docs/customize/login-pages/customize-consent-prompts).
@@ -56,7 +57,7 @@ Next, enable tenant-level flags required for Dynamic Client Registration (DCR) a
 Execute the following command to enable the above mentioned flags through the tenant settings:
 
 ```
-auth0 tenant-settings update set flags.enable_dynamic_client_registration flags.use_scope_descriptions_for_consent
+auth0 tenant-settings update set client_id_metadata_document_supported flags.enable_dynamic_client_registration flags.use_scope_descriptions_for_consent
 ```
 
 ### Step 3: Promote Connections to Domain Level

--- a/auth-for-mcp/nextjs-mcp-js/src/config.ts
+++ b/auth-for-mcp/nextjs-mcp-js/src/config.ts
@@ -12,5 +12,6 @@ export const MCP_SERVER_URL =
  */
 export const corsHeaders = {
   "Access-Control-Allow-Origin": "*", // Adjust as needed for production
-  "Access-Control-Allow-Methods": "GET, OPTIONS"
+  "Access-Control-Allow-Methods": "GET, OPTIONS",
+  "Content-Type": "application/json"
 };


### PR DESCRIPTION
This change applies a few small improvements for the upcoming Auth0 MCP CIMD rollout (further SDK / Quickstart improvements will come in future efforts/PRs):

1. Includes a new mention about the `client_id_metadata_document_supported` tenant setting (will soon be supported after the upcoming Manual CIMD rollout) and being added to the Auth0 CLI: https://github.com/auth0/auth0-cli/pull/1491
2. Small bugfix 🐛  - Ensures the [auth-for-mcp/nextjs-mcp-js](https://github.com/auth0-samples/auth0-ai-samples/tree/main/auth-for-mcp/nextjs-mcp-js) quickstart sets `content-type: application/json` headers with the `/.well-known/*` endpoints (e.g. .`/.well-known/oauth-authorization-server` and `/.well-known/oauth-protected-resource`). This bug was encountered while testing this quickstart alongside an OpenAI AppSDK integration, and has been [verified](https://github.com/priley86/demo-trade-pro-public/commit/b1a50f75bd6a94b6dd767eaff0886dde362b87c2) to work. (example: https://demo-trade-pro-agent.vercel.app/.well-known/oauth-authorization-server for running mcp server sample)